### PR TITLE
Export pdf

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -188,3 +188,89 @@ button:hover {
     display: inline-block; /* For multiple buttons side-by-side */
     margin: 5px;
 }
+
+/* Print specific styles */
+@media print {
+  body {
+    background-color: white !important; /* Ensure background is white for print */
+    color: black !important; /* Ensure text is black */
+    font-size: 12pt; /* Adjust base font size for print */
+  }
+
+  .no-print,
+  .no-print * { /* Hide elements with .no-print class and all their children */
+    display: none !important;
+  }
+
+  .print-only,
+  .print-only * { /* Ensure elements meant only for print are shown */
+    display: block !important; /* Use block, or table-row, etc. as appropriate for the element */
+    visibility: visible !important; /* Ensure visibility */
+  }
+  
+  /* Specifically for child paragraph elements within personal-info-display if they were part of a .no-print parent initially */
+  .personal-info-display.print-only p {
+      display: block !important; 
+      visibility: visible !important;
+  }
+
+  .resumeSection {
+    box-shadow: none !important;
+    border: 1px solid #ccc !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    margin-bottom: 15px !important;
+    padding: 15px !important;
+    width: 100% !important;
+    page-break-inside: avoid !important;
+    background-color: white !important; /* Ensure section backgrounds are white */
+    color: black !important; /* Ensure section text is black */
+  }
+
+  .resumeSection h2 {
+    font-size: 16pt !important;
+    margin-top: 0 !important;
+    border-bottom: 2px solid black !important;
+    padding-bottom: 5px !important;
+    color: black !important; /* Ensure heading text is black */
+  }
+
+  .resumeItem {
+    margin-bottom: 10px !important;
+    page-break-inside: avoid !important;
+  }
+  
+  .resumeItem h4 {
+    font-size: 14pt !important;
+    margin-bottom: 3px !important;
+    color: black !important;
+  }
+
+  .resumeItem p {
+    font-size: 11pt !important;
+    font-style: normal !important;
+    color: black !important;
+  }
+
+  .personal-info-section h2 { /* Keep the title for personal info section */
+      display: block !important;
+  }
+
+  .personal-info-display p strong {
+      color: black !important; /* Ensure strong text is black */
+  }
+
+  /* Hide the main App title explicitly if it wasn't caught by .no-print */
+  .App > h1 {
+    display: none !important;
+  }
+
+  /* Ensure modals are definitely hidden */
+  .modal {
+    display: none !important;
+  }
+  
+  br { /* Hide <br> tags that might cause unwanted spacing */
+      display: none !important;
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,11 @@ import InfoForm from './InfoForm'; // Import the new form
 const API_BASE_URL = 'http://localhost:5000'; // Assuming Python backend runs on port 5000
 
 function App() {
+  // Personal Information State
+  const [personName, setPersonName] = useState('John Doe'); // Example
+  const [personPhoneNumber, setPersonPhoneNumber] = useState('+1234567890'); // Example
+  const [personEmail, setPersonEmail] = useState('john.doe@example.com'); // Example
+
   const [experienceList, setExperienceList] = useState([]);
   const [educationList, setEducationList] = useState([]);
   const [showEducationForm, setShowEducationForm] = useState(false);
@@ -247,12 +252,28 @@ function App() {
 
   return (
     <div className="App">
-      <h1>Resume Builder</h1>
+      <h1 className="no-print">Resume Builder</h1>
 
       {/* Personal Info Section */}
-      <div className="resumeSection">
+      <div className="resumeSection personal-info-section">
         <h2>Personal Information</h2>
-        <InfoForm />
+        {/* Static display for printing */}
+        <div className="personal-info-display print-only">
+          <p><strong>Name:</strong> {personName}</p>
+          <p><strong>Phone:</strong> {personPhoneNumber}</p>
+          <p><strong>Email:</strong> {personEmail}</p>
+        </div>
+        {/* Editable Form for screen, will be hidden on print */}
+        <div className="info-form-wrapper no-print">
+          <InfoForm 
+            name={personName}
+            setName={setPersonName}
+            phoneNumber={personPhoneNumber}
+            setPhoneNumber={setPersonPhoneNumber}
+            email={personEmail}
+            setEmail={setPersonEmail}
+          />
+        </div>
       </div>
 
       {/* Experience Section */}
@@ -262,15 +283,15 @@ function App() {
           <div key={exp.id || index} className="resumeItem"> {/* Use a stable key */}
             <h4>{exp.title} at {exp.company}</h4>
             <p>{exp.description}</p>
-            <button onClick={() => handleOpenExperienceForm(exp)}>Edit</button>
+            <button className="no-print" onClick={() => handleOpenExperienceForm(exp)}>Edit</button>
             {/* TODO: Add Delete Button */}
           </div>
         ))}
-        <button onClick={() => handleOpenExperienceForm(null)}>Add Experience</button>
+        <button className="no-print" onClick={() => handleOpenExperienceForm(null)}>Add Experience</button>
       </div>
 
       {showExperienceForm && (
-        <div className="modal">
+        <div className="modal no-print">
           <div className="modal-content">
             <h3>{currentExperience ? 'Edit' : 'Add'} Experience</h3>
             <input type="text" name="title" value={experienceFormData.title} onChange={handleExperienceFormChange} placeholder="Title" />
@@ -280,7 +301,7 @@ function App() {
             <textarea name="description" value={experienceFormData.description} onChange={handleExperienceFormChange} placeholder="Description" />
             
             <div className="suggestions-container">
-              <button onClick={handleGetSuggestions} disabled={isLoadingSuggestions}>
+              <button className="no-print" onClick={handleGetSuggestions} disabled={isLoadingSuggestions}>
                 {isLoadingSuggestions ? 'Getting Suggestions...' : 'Get AI Suggestions'}
               </button>
               {descriptionSuggestions.length > 0 && (
@@ -296,8 +317,8 @@ function App() {
             
             {/* <input type="text" name="logo" value={experienceFormData.logo} onChange={handleExperienceFormChange} placeholder="Logo URL" /> */}
             <div className="modal-buttons">
-              <button onClick={handleSaveExperience}>Save Experience</button>
-              <button onClick={() => setShowExperienceForm(false)} className="cancel-btn">Cancel</button>
+              <button className="no-print" onClick={handleSaveExperience}>Save Experience</button>
+              <button className="no-print cancel-btn" onClick={() => setShowExperienceForm(false)}>Cancel</button>
             </div>
           </div>
         </div>
@@ -311,15 +332,15 @@ function App() {
             <h4>{edu.course} at {edu.school}</h4>
             <p><i>{edu.start_date} - {edu.end_date}, Grade: {edu.grade}</i></p>
             <p>{edu.description}</p>
-            <button onClick={() => handleOpenEducationForm(edu)}>Edit</button>
+            <button className="no-print" onClick={() => handleOpenEducationForm(edu)}>Edit</button>
             {/* TODO: Add Delete Button */}
           </div>
         ))}
-        <button onClick={() => handleOpenEducationForm(null)}>Add Education</button>
+        <button className="no-print" onClick={() => handleOpenEducationForm(null)}>Add Education</button>
       </div>
       
       {showEducationForm && (
-        <div className="modal">
+        <div className="modal no-print">
           <div className="modal-content">
             <h3>{currentEducation ? 'Edit' : 'Add'} Education</h3>
             <input type="text" name="course" value={educationFormData.course} onChange={handleEducationFormChange} placeholder="Course/Degree" />
@@ -330,7 +351,7 @@ function App() {
             <textarea name="description" value={educationFormData.description} onChange={handleEducationFormChange} placeholder="Description" />
             
             <div className="suggestions-container">
-              <button onClick={handleGetEducationSuggestions} disabled={isLoadingEducationSuggestions}>
+              <button className="no-print" onClick={handleGetEducationSuggestions} disabled={isLoadingEducationSuggestions}>
                 {isLoadingEducationSuggestions ? 'Getting Suggestions...' : 'Get AI Suggestions'}
               </button>
               {educationDescriptionSuggestions.length > 0 && (
@@ -346,8 +367,8 @@ function App() {
 
             {/* <input type="text" name="logo" value={educationFormData.logo} onChange={handleEducationFormChange} placeholder="Logo URL" /> */}
             <div className="modal-buttons">
-              <button onClick={handleSaveEducation}>Save Education</button>
-              <button onClick={() => setShowEducationForm(false)} className="cancel-btn">Cancel</button>
+              <button className="no-print" onClick={handleSaveEducation}>Save Education</button>
+              <button className="no-print cancel-btn" onClick={() => setShowEducationForm(false)}>Cancel</button>
             </div>
           </div>
         </div>
@@ -357,11 +378,11 @@ function App() {
       <div className="resumeSection">
         <h2>Skills</h2>
         <p>Skill Placeholder</p>
-        <button>Add Skill</button>
+        <button className="no-print">Add Skill</button>
       </div>
       
       <br />
-      <button>Export</button>
+      <button className="no-print" onClick={() => window.print()}>Export as PDF</button>
     </div>
   );
 }

--- a/src/InfoForm.js
+++ b/src/InfoForm.js
@@ -1,79 +1,47 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
-const InfoForm = () => {
-    const [name, setName] = useState('');
-    const [phoneNumber, setPhoneNumber] = useState('');
-    const [email, setEmail] = useState('');
-    const [isEditing, setIsEditing] = useState(false); // To simulate update vs add
-    const [userId, setUserId] = useState(null); // To simulate updating a specific user
+const InfoForm = ({ name, setName, phoneNumber, setPhoneNumber, email, setEmail }) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [userId, setUserId] = useState(null); 
+
+    useEffect(() => {
+        if (name === '' && phoneNumber === '' && email === '' && userId === null) {
+            setIsEditing(false);
+        }
+    }, [name, phoneNumber, email, userId]);
 
     const handleSubmit = async (event) => {
         event.preventDefault();
-
-        // Basic validation
         if (!name || !phoneNumber || !email) {
             alert('All fields are required.');
             return;
         }
-
         if (!/^\+\d+$/.test(phoneNumber)) {
             alert('Phone number must be in international format (e.g., +1234567890).');
             return;
         }
-
         if (!/\S+@\S+\.\S+/.test(email)) {
             alert('Please enter a valid email address.');
             return;
         }
-
         const userData = { name, phoneNumber, email };
-
         try {
-            let response;
             if (isEditing && userId) {
-                // Placeholder for UPDATE API call
-                console.log('Updating user:', userId, userData);
-                // response = await fetch(`/api/users/${userId}`, {
-                //     method: 'PUT',
-                //     headers: { 'Content-Type': 'application/json' },
-                //     body: JSON.stringify(userData),
-                // });
-                alert('User data update initiated (see console).'); // Placeholder
+                console.log('Updating user (via props):', userId, userData);
+                alert('User data update initiated (see console).'); 
             } else {
-                // Placeholder for ADD API call
-                console.log('Adding new user:', userData);
-                // response = await fetch('/api/users', {
-                //     method: 'POST',
-                //     headers: { 'Content-Type': 'application/json' },
-                //     body: JSON.stringify(userData),
-                // });
-                alert('User data submission initiated (see console).'); // Placeholder
+                console.log('Adding new user (via props):', userData);
+                alert('User data submission initiated (see console).');
             }
-
-            // const result = await response.json();
-            // if (response.ok) {
-            //     alert(`User data ${isEditing ? 'updated' : 'added'} successfully!`);
-            //     // Reset form or redirect, etc.
-            //     setName('');
-            //     setPhoneNumber('');
-            //     setEmail('');
-            //     setIsEditing(false);
-            //     setUserId(null);
-            // } else {
-            //     alert(`Error: ${result.message || 'Something went wrong.'}`);
-            // }
         } catch (error) {
             console.error('API call failed:', error);
             alert('API call failed. See console for details.');
         }
     };
 
-    // Dummy function to simulate loading data for editing
     const loadUserDataForEdit = (id) => {
-        // In a real app, you'd fetch this from a backend
         const dummyData = {
-            '123': { name: 'John Doe', phoneNumber: '+19876543210', email: 'john.doe@example.com' },
-            // Add more dummy users if needed
+            '123': { name: 'Jane Doe (Loaded)', phoneNumber: '+11234567890', email: 'jane.doe.loaded@example.com' },
         };
         if (dummyData[id]) {
             const user = dummyData[id];
@@ -87,11 +55,10 @@ const InfoForm = () => {
         }
     };
 
-
     return (
-        <div className="InfoForm-container">
-            <h2>{isEditing ? 'Update Information' : 'Add Information'}</h2>
-            <form onSubmit={handleSubmit}>
+        <div className="InfoForm-container no-print">
+            <h2 className="no-print">{isEditing ? 'Update Information' : 'Add Information'}</h2>
+            <form onSubmit={handleSubmit} className="no-print">
                 <div>
                     <label htmlFor="name">Name:</label>
                     <input
@@ -123,7 +90,7 @@ const InfoForm = () => {
                         required
                     />
                 </div>
-                <div className="form-buttons-container">
+                <div className="form-buttons-container no-print">
                     <button type="submit">{isEditing ? 'Update' : 'Add'}</button>
                     {!isEditing && (
                         <button type="button" onClick={() => loadUserDataForEdit('123')}>
@@ -132,11 +99,11 @@ const InfoForm = () => {
                     )}
                     {isEditing && (
                         <button type="button" onClick={() => {
-                            setIsEditing(false);
-                            setUserId(null);
-                            setName('');
+                            setName(''); 
                             setPhoneNumber('');
                             setEmail('');
+                            setIsEditing(false);
+                            setUserId(null);
                         }}>
                             Cancel Edit / Add New
                         </button>


### PR DESCRIPTION
**Implement PDF Resume Export and Refactor Personal Info**

This PR completes the issue mentioned here: https://github.com/MLH-Fellowship/orientation-project-js-25.sum.a/issues/13

Key changes include:
- Personal information state (name, phone, email) has been lifted from `InfoForm` to `App.js` to facilitate its display in the print view.
- `InfoForm` now receives and updates this personal information via props.
- CSS print styles (`@media print`) were added to `App.css`. These styles ensure only the resume content (Personal Info, Experience, Education, Skills) is included in the PDF, formatted for readability, while UI elements like forms and buttons are hidden.
